### PR TITLE
Fixed typos in band_erosion_tab.po

### DIFF
--- a/locale/transifex/LC_MESSAGES/band_erosion_tab.po
+++ b/locale/transifex/LC_MESSAGES/band_erosion_tab.po
@@ -207,7 +207,7 @@ msgstr ""
 
 #: ../../band_erosion_tab.rst:149
 msgid ""
-"set the class values to be dilated; class values must be separated by "
+"set the class values to be eroded; class values must be separated by "
 "``,`` and ``-`` can be used to define a range of values (e.g. ``1, 3-5, "
 "8`` will select classes 1, 3, 4, 5, 8); if the text is red then the "
 "expression contains errors"
@@ -218,7 +218,7 @@ msgid ":guilabel:`Size in pixels` |input_number|"
 msgstr ""
 
 #: ../../band_erosion_tab.rst:154
-msgid "number of pixels to be dilated from the border"
+msgid "number of pixels to be eroded from the border"
 msgstr ""
 
 #: ../../band_erosion_tab.rst:155


### PR DESCRIPTION
Some of the text strings of the band_erosion_tab refer to dilation instead of erosion, probably because the text was copied from one section to the other.